### PR TITLE
feat: use custom domain linkdex.dag.haus

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,7 @@
 # uncomment to use existing bucket (in same region)
 # if left commented out, we create a new, empty bucket.
 # BUCKET_NAME=dotstorage-staging-0
+
+# uncomment to try out deploying the api under a custom domain.
+# the value should match a hosted zone configured in route53 that your aws account has access to.
+# HOSTED_ZONE=linkdex.dag.haus

--- a/stacks/LinkdexStack.ts
+++ b/stacks/LinkdexStack.ts
@@ -29,6 +29,7 @@ export function LinkdexStack({ app, stack }: StackContext) {
     }
   })
   stack.addOutputs({
-    ApiEndpoint: api.url
+    ApiEndpoint: api.url,
+    CustomDomain: `https://${domain}`
   })
 }

--- a/stacks/LinkdexStack.ts
+++ b/stacks/LinkdexStack.ts
@@ -1,14 +1,21 @@
 import { StackContext, Api, Bucket } from "@serverless-stack/resources"
 import { aws_s3 as s3 } from 'aws-cdk-lib'
 
-export function LinkdexStack({ app,stack }: StackContext) {
+export function LinkdexStack({ app, stack }: StackContext) {
   // either import an existing bucket or create a new one for dev.
   // see: https://docs.sst.dev/advanced/importing-resources
   const bucket = (process.env.BUCKET_NAME)
     ? new Bucket(stack, 'existing-cars', { cdk: { bucket: s3.Bucket.fromBucketName(stack, 'imported-cars', process.env.BUCKET_NAME) }})
     : new Bucket(stack, 'cars')
 
+  const zone = 'linkdex.dag.haus'
+  const domain = app.stage === 'prod' ? zone : `${app.stage}.zone`
+
   const api = new Api(stack, "api", {
+    customDomain: { 
+      domainName: domain,
+      hostedZone: zone
+    },
     defaults: {
       function: {
         permissions: [bucket],

--- a/stacks/LinkdexStack.ts
+++ b/stacks/LinkdexStack.ts
@@ -9,7 +9,7 @@ export function LinkdexStack({ app, stack }: StackContext) {
     : new Bucket(stack, 'cars')
 
   const zone = 'linkdex.dag.haus'
-  const domain = app.stage === 'prod' ? zone : `${app.stage}.zone`
+  const domain = app.stage === 'prod' ? zone : `${app.stage}.${zone}`
 
   const api = new Api(stack, "api", {
     customDomain: { 


### PR DESCRIPTION
prod lives at `linkdex.dag.haus`
staging is at `staging.linkdex.dag.haus`

...all non-prod stages follow that pattern `${stage}.linkdex.dag.haus`

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>