### PR TITLE
feat: add aws resource tags

### DIFF
--- a/stacks/LinkdexStack.ts
+++ b/stacks/LinkdexStack.ts
@@ -18,7 +18,7 @@ export function LinkdexStack({ app, stack }: StackContext) {
         permissions: [bucket],
         environment: { BUCKET_NAME: bucket.bucketName },
         architecture: 'arm_64', // cheaper, so why not?
-        timeout: 0 // default is 10s
+        timeout: '15 minutes' // default is 10s
       }
     },
     routes: {

--- a/stacks/index.ts
+++ b/stacks/index.ts
@@ -16,6 +16,6 @@ export default function (app: App) {
   // see: https://docs.sst.dev/advanced/tagging-resources
   Tags.of(app).add('Project', 'linkdex-api')
   Tags.of(app).add('Repository', 'https://github.com/web3-storage/linkdex-api')
-  Tags.of(app).add("Environment", `${app.stage}-${app.region}`)
+  Tags.of(app).add("Environment", `${app.stage}`)
   Tags.of(app).add('ManagedBy', 'SST')
 }

--- a/stacks/index.ts
+++ b/stacks/index.ts
@@ -1,3 +1,4 @@
+import { Tags } from "aws-cdk-lib";
 import { LinkdexStack } from "./LinkdexStack";
 import { App } from "@serverless-stack/resources";
 
@@ -10,4 +11,11 @@ export default function (app: App) {
     },
   });
   app.stack(LinkdexStack);
+  
+  // tags let us discover all the aws resource costs incurred by this app
+  // see: https://docs.sst.dev/advanced/tagging-resources
+  Tags.of(app).add('Project', 'linkdex-api')
+  Tags.of(app).add('Repository', 'https://github.com/web3-storage/linkdex-api')
+  Tags.of(app).add("Environment", `${app.stage}-${app.region}`)
+  Tags.of(app).add('ManagedBy', 'SST')
 }


### PR DESCRIPTION
tags let us discover all the aws resource costs incurred by this app. see: https://docs.sst.dev/advanced/tagging-resources

existing tag names de-facto decided in:
- https://github.com/elastic-ipfs/infrastructure/blob/9d64210b0c4a0872a7bb9dda0a5a789524790b08/terraspace/config/terraform/provider.tf
- https://github.com/web3-storage/w3up/pull/192/files#diff-5817f07e292e15f736afda451ac2afa6642143cc58bbca545a736322042ef744R13-R18

see also: https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>