### PR TITLE
fix: use raw path

### DIFF
--- a/services/functions/linkdex-cid.ts
+++ b/services/functions/linkdex-cid.ts
@@ -19,7 +19,7 @@ export interface Report extends LDReport {
 const nullReport: Report = { cars: [], structure: 'Unknown', blocksIndexed: 0, uniqueCids: 0, undecodeable: 0 }
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
-  const cid = event.pathParameters?.cid ?? ''
+  const cid = event.rawPath.split('/cid/')[1]
   const bucket = process.env.BUCKET_NAME ?? ''
   const s3 = new S3Client({})
   const reporters = [new CompleteReporter(bucket, s3), new RawReporter(bucket, s3)]

--- a/stacks/LinkdexStack.ts
+++ b/stacks/LinkdexStack.ts
@@ -37,7 +37,6 @@ export function LinkdexStack({ app, stack }: StackContext) {
   })
 
   stack.addOutputs({
-    ApiEndpoint: api.url,
     CustomDomain: customDomain ? `https://${customDomain.domainName}` : 'Set HOSTED_ZONE in env to deploy to a custom domain'
   })
 }


### PR DESCRIPTION
When a lambda is accessed by `lambda-url` the event `pathParameters` property is `null`. Use `rawPath` instead.

Also removes the API URL since this is not the URL to access the lambda, and does not give you 15 minutes execution time.